### PR TITLE
Disable creating duplicate tax reports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,6 @@ module.exports = {
   plugins: ['@typescript-eslint/eslint-plugin'],
   extends: [
     'plugin:@typescript-eslint/recommended',
-    'plugin:prettier/recommended',
   ],
   root: true,
   env: {

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,12 @@
 {
   "singleQuote": true,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "overrides": [
+    {
+      "files": ["*.spec.ts", "*.spec-int.ts", "*.spec-e2e.ts"],
+      "options": {
+        "printWidth": 100
+      }
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@typescript-eslint/parser": "^5.0.0",
     "dotenv-cli": "^7.0.0",
     "eslint": "^8.0.1",
-    "eslint-plugin-prettier": "^4.0.0",
     "jest": "29.3.1",
     "prettier": "^2.3.2",
     "prisma": "^4.8.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@typescript-eslint/parser": "^5.0.0",
     "dotenv-cli": "^7.0.0",
     "eslint": "^8.0.1",
-    "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "29.3.1",
     "prettier": "^2.3.2",

--- a/src/app/app.controller.spec-e2e.ts
+++ b/src/app/app.controller.spec-e2e.ts
@@ -16,10 +16,7 @@ describe('AppController (e2e)', () => {
   });
 
   it('/ (GET)', () => {
-    return request(app.getHttpServer())
-      .get('/')
-      .expect(200)
-      .expect('Hello World!');
+    return request(app.getHttpServer()).get('/').expect(200).expect('Hello World!');
   });
 
   afterAll(async () => {

--- a/src/prisma/prisma.service.spec-int.ts
+++ b/src/prisma/prisma.service.spec-int.ts
@@ -15,10 +15,6 @@ describe('PrismaService (Integration)', () => {
     prismaService = app.get(PrismaService);
   });
 
-  it('should create', () => {
-    expect(prismaService).toBeDefined();
-  });
-
   it('should clean database', async () => {
     await prismaService.taxReport.createMany({
       data: [

--- a/src/tax-report/tax-report.controller.spec-e2e.ts
+++ b/src/tax-report/tax-report.controller.spec-e2e.ts
@@ -12,7 +12,7 @@ describe('TaxController (e2e)', () => {
 
   const today = new Date();
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
     }).compile();
@@ -23,9 +23,6 @@ describe('TaxController (e2e)', () => {
     req = request(app.getHttpServer());
 
     await app.init();
-  });
-
-  beforeEach(async () => {
     await prismaService.cleanDatabase();
   });
 
@@ -46,7 +43,7 @@ describe('TaxController (e2e)', () => {
 
     it('should throw an error when trying to create duplicate tax report', async () => {
       const taxReportDto: Prisma.TaxReportCreateInput = {
-        fiscalQuarter: 1,
+        fiscalQuarter: 2,
         fiscalYear: today.getFullYear(),
       };
 
@@ -61,7 +58,7 @@ describe('TaxController (e2e)', () => {
   describe('/tax-report (DELETE)', () => {
     it('should delete tax report', async () => {
       const taxReportDto: Prisma.TaxReportCreateInput = {
-        fiscalQuarter: 1,
+        fiscalQuarter: 3,
         fiscalYear: today.getFullYear(),
       };
 
@@ -76,7 +73,7 @@ describe('TaxController (e2e)', () => {
       // disable logging to not see error in terminal
       app.useLogger(false);
 
-      const { statusCode, error } = await req.delete('/tax-report/1');
+      const { statusCode, error } = await req.delete('/tax-report/-1');
 
       expect(statusCode).toEqual(HttpStatus.INTERNAL_SERVER_ERROR);
       expect(error).toEqual(expect.any(Error));

--- a/src/tax-report/tax-report.controller.spec-int.ts
+++ b/src/tax-report/tax-report.controller.spec-int.ts
@@ -18,9 +18,7 @@ describe('TaxReportController (Integration)', () => {
 
     prismaService = app.get(PrismaService);
     taxReportController = app.get(TaxReportController);
-  });
 
-  beforeEach(async () => {
     await prismaService.cleanDatabase();
   });
 
@@ -39,7 +37,7 @@ describe('TaxReportController (Integration)', () => {
 
     it('should throw an error when trying to create duplicate tax report', async () => {
       const taxReportDto: Prisma.TaxReportCreateInput = {
-        fiscalQuarter: 1,
+        fiscalQuarter: 2,
         fiscalYear: today.getFullYear(),
       };
 
@@ -54,7 +52,7 @@ describe('TaxReportController (Integration)', () => {
   describe('deleteTaxReport()', () => {
     it('should delete tax report', async () => {
       const taxReportDto: Prisma.TaxReportCreateInput = {
-        fiscalQuarter: 1,
+        fiscalQuarter: 3,
         fiscalYear: today.getFullYear(),
       };
 
@@ -69,7 +67,7 @@ describe('TaxReportController (Integration)', () => {
     });
 
     it('should throw an error when trying to delete report that does not exist', () => {
-      const deleteTaxReportId = 1;
+      const deleteTaxReportId = -1;
 
       expect(taxReportController.deleteTaxReport(`${deleteTaxReportId}`)).rejects.toThrow(Error);
     });

--- a/src/tax-report/tax-report.controller.spec-int.ts
+++ b/src/tax-report/tax-report.controller.spec-int.ts
@@ -3,6 +3,7 @@ import { Prisma } from '@prisma/client';
 import { AppModule } from '../app/app.module';
 import { PrismaService } from '../prisma/prisma.service';
 import { TaxReportController } from './tax-report.controller';
+import { DuplicateTaxReportException } from './tax-report.exception';
 
 describe('TaxReportController (Integration)', () => {
   let taxReportController: TaxReportController;
@@ -17,62 +18,60 @@ describe('TaxReportController (Integration)', () => {
 
     prismaService = app.get(PrismaService);
     taxReportController = app.get(TaxReportController);
-
-    await prismaService.cleanDatabase();
   });
 
-  it('should create', () => {
-    expect(taxReportController).toBeDefined();
+  beforeEach(async () => {
+    await prismaService.cleanDatabase();
   });
 
   describe('createTaxReport()', () => {
     it('should create tax report', async () => {
-      const createTaxReportDto: Prisma.TaxReportCreateInput = {
+      const taxReportDto: Prisma.TaxReportCreateInput = {
         fiscalQuarter: 1,
         fiscalYear: today.getFullYear(),
       };
-      const taxReport = await taxReportController.createTaxReport(
-        createTaxReportDto,
-      );
+      const taxReport = await taxReportController.createTaxReport(taxReportDto);
 
       expect(taxReport.id).toEqual(expect.any(Number));
-      expect(taxReport.fiscalQuarter).toBe(createTaxReportDto.fiscalQuarter);
-      expect(taxReport.fiscalYear).toBe(createTaxReportDto.fiscalYear);
+      expect(taxReport.fiscalQuarter).toBe(taxReportDto.fiscalQuarter);
+      expect(taxReport.fiscalYear).toBe(taxReportDto.fiscalYear);
+    });
+
+    it('should throw an error when trying to create duplicate tax report', async () => {
+      const taxReportDto: Prisma.TaxReportCreateInput = {
+        fiscalQuarter: 1,
+        fiscalYear: today.getFullYear(),
+      };
+
+      await taxReportController.createTaxReport(taxReportDto);
+
+      expect(taxReportController.createTaxReport(taxReportDto)).rejects.toThrow(
+        DuplicateTaxReportException,
+      );
     });
   });
 
   describe('deleteTaxReport()', () => {
     it('should delete tax report', async () => {
-      const createTaxReportDto: Prisma.TaxReportCreateInput = {
+      const taxReportDto: Prisma.TaxReportCreateInput = {
         fiscalQuarter: 1,
         fiscalYear: today.getFullYear(),
       };
-      const { id } = await taxReportController.createTaxReport(
-        createTaxReportDto,
-      );
-      const taxReportDeleted = await taxReportController.deleteTaxReport(
-        id.toString(),
-      );
-      const taxReportFound = await prismaService.taxReport.findFirst({
-        where: { id },
-      });
+
+      const { id } = await taxReportController.createTaxReport(taxReportDto);
+      const taxReportDeleted = await taxReportController.deleteTaxReport(id.toString());
+      const taxReportFound = await prismaService.taxReport.findFirst({ where: { id } });
 
       expect(taxReportDeleted.id).toEqual(id);
-      expect(taxReportDeleted.fiscalQuarter).toBe(
-        createTaxReportDto.fiscalQuarter,
-      );
-      expect(taxReportDeleted.fiscalYear).toBe(createTaxReportDto.fiscalYear);
+      expect(taxReportDeleted.fiscalQuarter).toBe(taxReportDto.fiscalQuarter);
+      expect(taxReportDeleted.fiscalYear).toBe(taxReportDto.fiscalYear);
       expect(taxReportFound).toBeNull();
     });
 
-    it('should throw an error when trying to delete report that does not exist', async () => {
+    it('should throw an error when trying to delete report that does not exist', () => {
       const deleteTaxReportId = 1;
 
-      try {
-        await taxReportController.deleteTaxReport(deleteTaxReportId.toString());
-      } catch (error) {
-        expect(error).toEqual(expect.any(Error));
-      }
+      expect(taxReportController.deleteTaxReport(`${deleteTaxReportId}`)).rejects.toThrow(Error);
     });
   });
 });

--- a/src/tax-report/tax-report.controller.ts
+++ b/src/tax-report/tax-report.controller.ts
@@ -8,9 +8,9 @@ export class TaxReportController {
 
   @Post()
   async createTaxReport(
-    @Body() createTaxReportDto: Prisma.TaxReportCreateInput,
+    @Body() taxReportDto: Prisma.TaxReportCreateInput,
   ): Promise<TaxReport> {
-    return this.taxReportService.createTaxReport(createTaxReportDto);
+    return this.taxReportService.createTaxReport(taxReportDto);
   }
 
   @Delete(':taxReportId')

--- a/src/tax-report/tax-report.exception.ts
+++ b/src/tax-report/tax-report.exception.ts
@@ -1,0 +1,7 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export class DuplicateTaxReportException extends HttpException {
+  constructor() {
+    super('Tax Report already exists', HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+}

--- a/src/tax-report/tax-report.service.spec-int.ts
+++ b/src/tax-report/tax-report.service.spec-int.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { Prisma } from '@prisma/client';
 import { AppModule } from '../app/app.module';
 import { PrismaService } from '../prisma/prisma.service';
+import { DuplicateTaxReportException } from './tax-report.exception';
 import { TaxReportService } from './tax-report.service';
 
 describe('TaxReportService (Integration)', () => {
@@ -17,58 +18,58 @@ describe('TaxReportService (Integration)', () => {
 
     prismaService = app.get(PrismaService);
     taxReportService = app.get(TaxReportService);
-
-    await prismaService.cleanDatabase();
   });
 
-  it('should create', () => {
-    expect(taxReportService).toBeDefined();
+  beforeEach(async () => {
+    await prismaService.cleanDatabase();
   });
 
   describe('createTaxReport()', () => {
     it('should create tax report', async () => {
-      const createTaxReportDto: Prisma.TaxReportCreateInput = {
+      const taxReportDto: Prisma.TaxReportCreateInput = {
         fiscalQuarter: 1,
         fiscalYear: today.getFullYear(),
       };
-      const taxReport = await taxReportService.createTaxReport(
-        createTaxReportDto,
-      );
+      const taxReport = await taxReportService.createTaxReport(taxReportDto);
 
       expect(taxReport.id).toEqual(expect.any(Number));
-      expect(taxReport.fiscalQuarter).toBe(createTaxReportDto.fiscalQuarter);
-      expect(taxReport.fiscalYear).toBe(createTaxReportDto.fiscalYear);
+      expect(taxReport.fiscalQuarter).toBe(taxReportDto.fiscalQuarter);
+      expect(taxReport.fiscalYear).toBe(taxReportDto.fiscalYear);
+    });
+
+    it('should throw an error when trying to create duplicate tax report', async () => {
+      const taxReportDto: Prisma.TaxReportCreateInput = {
+        fiscalQuarter: 1,
+        fiscalYear: today.getFullYear(),
+      };
+
+      await taxReportService.createTaxReport(taxReportDto);
+      expect(taxReportService.createTaxReport(taxReportDto)).rejects.toThrow(
+        DuplicateTaxReportException,
+      );
     });
   });
 
   describe('deleteTaxReport()', () => {
     it('should delete tax report', async () => {
-      const createTaxReportDto: Prisma.TaxReportCreateInput = {
+      const taxReportDto: Prisma.TaxReportCreateInput = {
         fiscalQuarter: 1,
         fiscalYear: today.getFullYear(),
       };
-      const { id } = await taxReportService.createTaxReport(createTaxReportDto);
+      const { id } = await taxReportService.createTaxReport(taxReportDto);
       const taxReportDeleted = await taxReportService.deleteTaxReport(id);
-      const taxReportFound = await prismaService.taxReport.findFirst({
-        where: { id },
-      });
+      const taxReportFound = await prismaService.taxReport.findFirst({ where: { id } });
 
       expect(taxReportDeleted.id).toEqual(id);
-      expect(taxReportDeleted.fiscalQuarter).toBe(
-        createTaxReportDto.fiscalQuarter,
-      );
-      expect(taxReportDeleted.fiscalYear).toBe(createTaxReportDto.fiscalYear);
+      expect(taxReportDeleted.fiscalQuarter).toBe(taxReportDto.fiscalQuarter);
+      expect(taxReportDeleted.fiscalYear).toBe(taxReportDto.fiscalYear);
       expect(taxReportFound).toBeNull();
     });
 
-    it('should throw an error when trying to delete report that does not exist', async () => {
+    it('should throw an error when trying to delete tax report that does not exist', async () => {
       const deleteTaxReportId = 1;
 
-      try {
-        await taxReportService.deleteTaxReport(deleteTaxReportId);
-      } catch (error) {
-        expect(error).toEqual(expect.any(Error));
-      }
+      expect(taxReportService.deleteTaxReport(deleteTaxReportId)).rejects.toThrow(Error);
     });
   });
 });

--- a/src/tax-report/tax-report.service.spec-int.ts
+++ b/src/tax-report/tax-report.service.spec-int.ts
@@ -18,9 +18,7 @@ describe('TaxReportService (Integration)', () => {
 
     prismaService = app.get(PrismaService);
     taxReportService = app.get(TaxReportService);
-  });
-
-  beforeEach(async () => {
+    
     await prismaService.cleanDatabase();
   });
 
@@ -39,7 +37,7 @@ describe('TaxReportService (Integration)', () => {
 
     it('should throw an error when trying to create duplicate tax report', async () => {
       const taxReportDto: Prisma.TaxReportCreateInput = {
-        fiscalQuarter: 1,
+        fiscalQuarter: 2,
         fiscalYear: today.getFullYear(),
       };
 
@@ -53,7 +51,7 @@ describe('TaxReportService (Integration)', () => {
   describe('deleteTaxReport()', () => {
     it('should delete tax report', async () => {
       const taxReportDto: Prisma.TaxReportCreateInput = {
-        fiscalQuarter: 1,
+        fiscalQuarter: 3,
         fiscalYear: today.getFullYear(),
       };
       const { id } = await taxReportService.createTaxReport(taxReportDto);

--- a/src/tax-report/tax-report.service.ts
+++ b/src/tax-report/tax-report.service.ts
@@ -1,16 +1,28 @@
 import { Injectable } from '@nestjs/common';
 import { Prisma, TaxReport } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
+import { DuplicateTaxReportException } from './tax-report.exception';
 
 @Injectable()
 export class TaxReportService {
   constructor(private readonly prisma: PrismaService) {}
 
   async createTaxReport(
-    createTaxReportDto: Prisma.TaxReportCreateInput,
+    taxReportDto: Prisma.TaxReportCreateInput,
   ): Promise<TaxReport> {
+    const isDuplicateTaxReport = await this.prisma.taxReport.findFirst({
+      where: {
+        fiscalQuarter: taxReportDto.fiscalQuarter,
+        fiscalYear: taxReportDto.fiscalYear,
+      },
+    });
+
+    if (isDuplicateTaxReport) {
+      throw new DuplicateTaxReportException();
+    }
+
     return this.prisma.taxReport.create({
-      data: createTaxReportDto,
+      data: taxReportDto,
     });
   }
 


### PR DESCRIPTION
# Problem / Requirement

As a user, I should not be able to create duplicate tax reports

# Solution

When creating a tax report, check the tax report is unique by its fiscalQuarter and ficalYear.